### PR TITLE
Add support for GitHub Copilot Metrics API 422 error responses

### DIFF
--- a/src/dashboard/features/common/response-error.ts
+++ b/src/dashboard/features/common/response-error.ts
@@ -23,6 +23,9 @@ export const formatResponseError = (
       status = "NOT_FOUND";
       message = `Entity with the name ${entity} was not found.`;
       break;
+    case 422:
+      message = `Your organization has disabled Copilot Metrics API access for ${entity}. Enable it in GitHub settings to access this data.`;
+      break;
     case 429:
       message = `Too many requests. Rate limit exceeded for ${entity}. Please try again later.`;
       break;


### PR DESCRIPTION
**Description**

This PR adds proper error handling for the 422 HTTP status code returned by the GitHub Copilot Metrics API. When organizations have disabled Copilot Metrics API access (I think this is the default setting), the GitHub API returns a 422 status code with a specific error message.

The error handler now properly interprets this response and provides users with a clear message explaining that:

- Their organization has disabled Copilot Metrics API access
- This is why they cannot access the requested data
- They need to enable this feature in GitHub settings to access the metrics

**Why**

Previously, users encountering this error would receive a generic HTTP status message that didn't clearly explain why the request failed or how to resolve it. This improvement provides actionable guidance and improves the overall user experience when encountering permission issues.

**Before:**
<img width="632" alt="Screenshot 2025-06-02 at 15 22 08" src="https://github.com/user-attachments/assets/97d59c98-25af-4ec0-a91a-148c0ca1b688" />
    
**After:**
<img width="639" alt="Screenshot 2025-06-02 at 15 22 53" src="https://github.com/user-attachments/assets/397fa8ae-0029-4571-b349-d9f32bf8764d" />
