### PR TITLE
Fix for unselectable team filter

### DIFF
--- a/src/dashboard/features/dashboard/filter/dropdown-filter.tsx
+++ b/src/dashboard/features/dashboard/filter/dropdown-filter.tsx
@@ -67,7 +67,10 @@ export function DropdownFilter(props: DropdownFilterProps) {
                   return (
                     <CommandItem
                       key={option.value}
-                      onSelect={onSelect}
+                      // Call the provided onSelect explicitly with the option value.
+                      // This avoids relying on the underlying CommandItem's onSelect
+                      // signature which may pass different args.
+                      onSelect={() => onSelect(option.value)}
                       value={option.value}
                     >
                       <div


### PR DESCRIPTION
This pull request makes a targeted update to the `DropdownFilter` component to improve how selection events are handled. Instead of relying on the default behavior of `CommandItem`'s `onSelect`, the change ensures that the provided `onSelect` callback is always called with the correct option value.

* Updated the `onSelect` handler in `DropdownFilter` so that it explicitly calls the provided `onSelect` function with the selected option's value, making the selection logic more predictable and robust.