### PR TITLE
Migrate metrics to the user-day usage report (legacy /copilot/metrics API was sunset 2026-04-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 # Introduction
 
-The GitHub Copilot Metrics Dashboard is a solution accelerator designed to visualize metrics from GitHub Copilot using the [GitHub Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics?apiVersion=2022-11-28) and [GitHub Copilot User Management API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-user-management?apiVersion=2022-11-28).
+The GitHub Copilot Metrics Dashboard is a solution accelerator designed to visualize metrics from GitHub Copilot using the [Copilot usage-metrics report API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics?apiVersion=2022-11-28) (`/copilot/metrics/reports/users-28-day/latest`) and the [GitHub Copilot User Management API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-user-management?apiVersion=2022-11-28). See [docs/metrics-ingestion.md](docs/metrics-ingestion.md) for a detailed explanation of how raw report data is fetched and aggregated.
 
 ## Dashboard
 
@@ -58,16 +58,15 @@ To run the dashboard on your local machine, head to the **dashboard** folder und
 ```
 #### Environment Variables
 
-You will be required to enter the following information in an **.env** file:
+Copy `src/dashboard/.env.example` to `src/dashboard/.env` and fill in the following:
 
-```
-- GitHub Enterprise name
-- GitHub Organization name
-- GitHub Token
-- GitHub API Scope
-```
-
-You can use the **.env.example** file as a reference. GitHub API Scope defines the GITHUB_API_SCOPE environment variable and can be set to either "enterprise" or "organization". It is used to define at which level the GitHub APIs will gather data. If not specified, the default value is "organization".
+| Variable | Required | Description |
+|---|---|---|
+| `GITHUB_API_SCOPE` | No (default: `organization`) | `organization` or `enterprise` — sets the API scope. |
+| `GITHUB_ORGANIZATION` | When scope is `organization` | Your GitHub org slug. |
+| `GITHUB_ENTERPRISE` | When scope is `enterprise` | Your GitHub enterprise slug. |
+| `GITHUB_TOKEN` | Yes | PAT with `read:org`, `read:user`, and `copilot` scopes (add `read:enterprise` for enterprise scope). |
+| `GITHUB_API_VERSION` | Yes | GitHub API version — use `2022-11-28`. |
 
 #### Install & Run
 
@@ -118,16 +117,16 @@ The following steps will automatically provision Azure resources and deploy the 
 
 You will be prompted to provide the following information:
 
-```
-- GitHub Enterprise name
-- GitHub Organization name
-- GitHub Token
-- GitHub API Scope
-```
+| Variable | Required | Description |
+|---|---|---|
+| `GITHUB_API_SCOPE` | No (default: `organization`) | `organization` or `enterprise`. |
+| `GITHUB_ORGANIZATION` | When scope is `organization` | Your GitHub org slug. |
+| `GITHUB_ENTERPRISE` | When scope is `enterprise` | Your GitHub enterprise slug. |
+| `GITHUB_TOKEN` | Yes | PAT — see [Token Requirements](infra/README.md#github-token-requirements). |
 
-> More details here for the [GA Metrics API](https://github.blog/changelog/2024-10-30-github-copilot-metrics-api-ga-release-now-available/)
+> **Note:** The Azure deployment (Bicep) still prompts for **both** org and enterprise names even though only one is used at runtime. Set the unused value to a placeholder (e.g. `n/a`) if your scope doesn't require it.
 
-GitHub API Scope defines the GITHUB_API_SCOPE environment variable and can be set to either "enterprise" or "organization". It is used to define at which level the GitHub APIs will gather data. If not specified, the default value is "organization".
+> More details for the [Copilot usage-metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics?apiVersion=2022-11-28) and the [GA announcement](https://github.blog/changelog/2024-10-30-github-copilot-metrics-api-ga-release-now-available/).
 
 1. Download the [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/overview)
 2. If you have not cloned this repo, run `azd init -t microsoft/copilot-metrics-dashboard`. If you have cloned this repo, just run 'azd init' from the repo root directory.

--- a/docs/metrics-ingestion.md
+++ b/docs/metrics-ingestion.md
@@ -1,0 +1,124 @@
+# Copilot metrics ingestion
+
+This note explains how the dashboard turns raw GitHub Copilot data into
+the per-day, per-team series that drives the charts. The implementation
+lives in [`src/dashboard/services/copilot-metrics-service.ts`](../src/dashboard/services/copilot-metrics-service.ts).
+
+## Data sources
+
+The service has three back-ends and picks the first one that is
+configured for the current request:
+
+| Back-end | When | Notes |
+| --- | --- | --- |
+| **CosmosDB** | `AZURE_COSMOSDB_ENDPOINT` is set | Reads pre-ingested daily snapshots written by the Azure Function. Best for production where we don't want to hit GitHub on every page load. |
+| **GitHub API (live)** | No CosmosDB endpoint, but `GITHUB_TOKEN` is set | Pulls fresh data from GitHub on every request. Used for local development and small deployments. |
+| **Sample data** | Neither of the above | Lets contributors run the UI without any credentials. |
+
+This document focuses on the **GitHub API (live)** path because that's
+where the recent changes were made.
+
+## The live path, step by step
+
+```
+                +-----------------------------------------+
+                |  GET /copilot/metrics/reports/          |
+                |  users-28-day/latest                    |
+                |  -> { download_links: [url1, url2,...] }|
+                +-----------------------------------------+
+                                  |
+                                  v
+                  for each download_link:
+                +-----------------------------------------+
+                |  GET <download_link>                    |
+                |  -> JSON array OR NDJSON of             |
+                |     UsageMetricsUserDayRecord rows      |
+                +-----------------------------------------+
+                                  |
+                                  v
+                +-----------------------------------------+
+                |  GET /copilot/billing/seats?per_page=100|
+                |  -> SeatAssignment[]                    |
+                |  (paginated; follow Link: rel="next")   |
+                +-----------------------------------------+
+                                  |
+                                  v
+                +-----------------------------------------+
+                |  Build a `userLogin -> teams[]` lookup  |
+                |  from the seat assignments.             |
+                +-----------------------------------------+
+                                  |
+                                  v
+                +-----------------------------------------+
+                |  For each usage record:                 |
+                |   - filter by selected date range       |
+                |   - filter by selected teams (if any)   |
+                |   - bucket the totals by                |
+                |     (day, language, IDE, feature)       |
+                |  Then merge into CopilotUsageOutput[]   |
+                +-----------------------------------------+
+```
+
+## Why we switched from the per-day metrics endpoint
+
+The previous per-day endpoint (`/orgs/{org}/copilot/metrics`) returns
+already-aggregated counters by day, IDE and language. It does **not**
+include per-user information, which means we cannot:
+
+- Distinguish licensed-but-inactive users from engaged users.
+- Group activity by team without making one extra API call per team.
+- Cleanly separate chat usage from completion usage.
+
+The user-day usage report exposes the underlying per-user, per-day rows
+(`UsageMetricsUserDayRecord`), so all three become local computations.
+The trade-off is that we have to download and aggregate the report
+ourselves, which is what most of the new code in
+`copilot-metrics-service.ts` is doing.
+
+## Field reference (UsageMetricsUserDayRecord)
+
+The shape we consume from GitHub. Every numeric field is optional and
+treated as `0` when missing.
+
+| Field | Meaning |
+| --- | --- |
+| `day` | ISO date (`YYYY-MM-DD`) the activity is attributed to. |
+| `user_login` | GitHub login of the user. |
+| `used_chat`, `used_agent`, `used_cli`, ... | Booleans flagging which surfaces the user touched that day. |
+| `code_generation_activity_count` | Times the user triggered a completion suggestion. |
+| `code_acceptance_activity_count` | Times the user accepted one. |
+| `loc_suggested_to_add_sum`, `loc_suggested_to_delete_sum` | Lines suggested. |
+| `loc_added_sum`, `loc_deleted_sum` | Lines actually accepted. |
+| `user_initiated_interaction_count` | Catch-all for chat / agent prompts. |
+| `totals_by_ide` | Same totals broken down by IDE. |
+| `totals_by_feature` | Same totals broken down by Copilot feature. |
+| `totals_by_language_feature` | Three-way breakdown by language and feature. |
+
+A user is considered **engaged** on a day if any of the activity
+counters above is greater than 0. Anything else (i.e. the seat exists
+but no surface was touched) is "licensed-but-inactive".
+
+## Environment variables
+
+The metrics service relies on `services/env-service.ts` to validate the
+following:
+
+| Variable | Required when | Notes |
+| --- | --- | --- |
+| `GITHUB_API_SCOPE` | always (defaults to `organization`) | Either `organization` or `enterprise`. |
+| `GITHUB_ORGANIZATION` | scope is `organization` | The org slug. Ignored for enterprise scope. |
+| `GITHUB_ENTERPRISE`   | scope is `enterprise`   | The enterprise slug. Ignored for organization scope. |
+| `GITHUB_TOKEN` | always | PAT or fine-grained token with Copilot read access. |
+| `GITHUB_API_VERSION` | always | Currently `2022-11-28`. |
+
+Previously the service required **all** of these regardless of scope,
+which forced org users to set a dummy `GITHUB_ENTERPRISE`. That has been
+relaxed.
+
+## TypeScript target
+
+The aggregation helpers iterate over `Set` values, which TypeScript
+refuses to compile under the default `target: "es5"`. `tsconfig.json`
+sets `target: "es2015"` to allow native iteration. All Node versions the
+dashboard supports run ES2015 natively, so this is purely a compile-time
+flag.

--- a/infra/README.md
+++ b/infra/README.md
@@ -42,10 +42,10 @@ The Cosmos DB database (`platform-engineering`) contains three containers:
 |-----------|-------------|---------|
 | `name` | Environment name (1-64 chars) | `copilot-metrics-prod` |
 | `location` | Azure region | `eastus` |
-| `githubEnterpriseName` | GitHub Enterprise name | `contoso` |
-| `githubOrganizationName` | GitHub Organization name | `contoso-engineering` |
-| `githubAPIScope` | API scope (`enterprise` or `organization`) | `organization` |
-| `githubToken` | GitHub Personal Access Token (secure) | `ghp_xxxxx` |
+| `githubEnterpriseName` | GitHub Enterprise slug — **required by the Bicep template**; if `githubAPIScope` is `organization` this value is stored but not used at runtime (set it to a placeholder such as `n/a`) | `contoso` |
+| `githubOrganizationName` | GitHub Organization slug — **required by the Bicep template**; if `githubAPIScope` is `enterprise` this value is stored but not used at runtime (set it to a placeholder such as `n/a`) | `contoso-engineering` |
+| `githubAPIScope` | API scope (`enterprise` or `organization`) — determines which of the two values above is actually used | `organization` |
+| `githubToken` | GitHub Personal Access Token (secure) — see [Token Requirements](#github-token-requirements) | `ghp_xxxxx` |
 
 ### Optional Parameters
 
@@ -83,9 +83,14 @@ The GitHub Personal Access Token must have the following scopes:
 azd init
 
 # Set environment variables
-azd env set GITHUB_ENTERPRISE_NAME "your-enterprise"
-azd env set GITHUB_ORGANIZATION_NAME "your-organization"
+# Set the scope to 'organization' or 'enterprise'
 azd env set GITHUB_API_SCOPE "organization"
+
+# Set the org slug (required when scope is 'organization'; use a placeholder for 'enterprise')
+azd env set GITHUB_ORGANIZATION_NAME "your-organization"
+azd env set GITHUB_ENTERPRISE_NAME "n/a"
+
+# Set the GitHub PAT and API version
 azd env set GITHUB_TOKEN "your-github-token"
 
 # Deploy to Azure

--- a/src/dashboard/services/copilot-metrics-service.ts
+++ b/src/dashboard/services/copilot-metrics-service.ts
@@ -1,11 +1,20 @@
 import { formatResponseError, unknownResponseError } from "@/features/common/response-error";
-import { CopilotMetrics, CopilotUsageOutput } from "@/features/common/models";
+import {
+  Breakdown,
+  CopilotMetrics,
+  CopilotUsageOutput,
+  SeatAssignment,
+} from "@/features/common/models";
 import { ServerActionResponse } from "@/features/common/server-action-response";
 import { SqlQuerySpec } from "@azure/cosmos";
-import { format } from "date-fns";
+import { format, startOfWeek } from "date-fns";
 import { cosmosClient, cosmosConfiguration } from "./cosmos-db-service";
 import { ensureGitHubEnvConfig } from "./env-service";
-import { stringIsNullOrEmpty, applyTimeFrameLabel } from "../utils/helpers";
+import {
+  applyTimeFrameLabel,
+  getNextUrlFromLinkHeader,
+  stringIsNullOrEmpty,
+} from "../utils/helpers";
 import { sampleData } from "./sample-data";
 
 export interface IFilter {
@@ -16,8 +25,594 @@ export interface IFilter {
   team: string[];
 }
 
+interface UsageMetricsReportResponse {
+  download_links: string[];
+  report_start_day?: string;
+  report_end_day?: string;
+  report_day?: string;
+}
+
+interface UsageMetricsTotal {
+  user_initiated_interaction_count?: number;
+  code_generation_activity_count?: number;
+  code_acceptance_activity_count?: number;
+  loc_suggested_to_add_sum?: number;
+  loc_suggested_to_delete_sum?: number;
+  loc_added_sum?: number;
+  loc_deleted_sum?: number;
+}
+
+interface UsageMetricsIdeTotal extends UsageMetricsTotal {
+  ide: string;
+}
+
+interface UsageMetricsFeatureTotal extends UsageMetricsTotal {
+  feature: string;
+}
+
+interface UsageMetricsLanguageFeatureTotal extends UsageMetricsTotal {
+  language: string;
+  feature: string;
+}
+
+interface UsageMetricsUserDayRecord extends UsageMetricsTotal {
+  day: string;
+  user_login: string;
+  used_chat?: boolean;
+  used_agent?: boolean;
+  used_cli?: boolean;
+  used_copilot_cloud_agent?: boolean;
+  used_copilot_coding_agent?: boolean;
+  totals_by_ide?: UsageMetricsIdeTotal[];
+  totals_by_feature?: UsageMetricsFeatureTotal[];
+  totals_by_language_feature?: UsageMetricsLanguageFeatureTotal[];
+}
+
+const CODE_COMPLETION_FEATURE = "code_completion";
+
+const asNumber = (value?: number | null) => value ?? 0;
+
+const totalSuggestedLines = (total: UsageMetricsTotal) =>
+  asNumber(total.loc_suggested_to_add_sum) +
+  asNumber(total.loc_suggested_to_delete_sum);
+
+const totalAcceptedLines = (total: UsageMetricsTotal) =>
+  asNumber(total.loc_added_sum) + asNumber(total.loc_deleted_sum);
+
+const hasUsageActivity = (total: UsageMetricsTotal) =>
+  asNumber(total.code_generation_activity_count) > 0 ||
+  asNumber(total.code_acceptance_activity_count) > 0 ||
+  totalSuggestedLines(total) > 0 ||
+  totalAcceptedLines(total) > 0 ||
+  asNumber(total.user_initiated_interaction_count) > 0;
+
+const isChatFeature = (feature: string) =>
+  feature.startsWith("chat_") || feature.includes("agent");
+
+const scaleMetric = (value: number, factor: number) =>
+  Number((value * factor).toFixed(4));
+
+const getEntityName = (filter: IFilter) =>
+  filter.enterprise || filter.organization;
+
+const buildUsageUsersReportUrl = (filter: IFilter) => {
+  if (filter.enterprise) {
+    return `https://api.github.com/enterprises/${filter.enterprise}/copilot/metrics/reports/users-28-day/latest`;
+  }
+
+  return `https://api.github.com/orgs/${filter.organization}/copilot/metrics/reports/users-28-day/latest`;
+};
+
+const buildSeatsUrl = (filter: IFilter) => {
+  if (filter.enterprise) {
+    return `https://api.github.com/enterprises/${filter.enterprise}/copilot/billing/seats?per_page=100`;
+  }
+
+  return `https://api.github.com/orgs/${filter.organization}/copilot/billing/seats?per_page=100`;
+};
+
+const parseUsageUserReport = (
+  rawReport: string,
+): UsageMetricsUserDayRecord[] => {
+  const trimmedReport = rawReport.trim();
+
+  if (!trimmedReport) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmedReport);
+
+    if (Array.isArray(parsed)) {
+      return parsed as UsageMetricsUserDayRecord[];
+    }
+
+    return [parsed as UsageMetricsUserDayRecord];
+  } catch {
+    return trimmedReport
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as UsageMetricsUserDayRecord);
+  }
+};
+
+const fetchGitHubJson = async <T>(
+  url: string,
+  token: string,
+  version: string,
+  entityName: string,
+): Promise<ServerActionResponse<T>> => {
+  const response = await fetch(url, {
+    cache: "no-store",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": version,
+    },
+  });
+
+  if (!response.ok) {
+    return formatResponseError(entityName, response);
+  }
+
+  return {
+    status: "OK",
+    response: (await response.json()) as T,
+  };
+};
+
+const downloadUsageReport = async (
+  downloadLink: string,
+): Promise<ServerActionResponse<UsageMetricsUserDayRecord[]>> => {
+  const response = await fetch(downloadLink, {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return {
+      status: "ERROR",
+      errors: [{ message: "Failed to download Copilot usage metrics report" }],
+    };
+  }
+
+  const reportText = await response.text();
+
+  return {
+    status: "OK",
+    response: parseUsageUserReport(reportText),
+  };
+};
+
+const fetchUsageUserDayRecords = async (
+  filter: IFilter,
+  token: string,
+  version: string,
+): Promise<ServerActionResponse<UsageMetricsUserDayRecord[]>> => {
+  const entityName = getEntityName(filter);
+  const reportResponse = await fetchGitHubJson<UsageMetricsReportResponse>(
+    buildUsageUsersReportUrl(filter),
+    token,
+    version,
+    entityName,
+  );
+
+  if (reportResponse.status !== "OK") {
+    return reportResponse;
+  }
+
+  const usageRecords: UsageMetricsUserDayRecord[] = [];
+
+  for (const downloadLink of reportResponse.response.download_links || []) {
+    const downloadResponse = await downloadUsageReport(downloadLink);
+
+    if (downloadResponse.status !== "OK") {
+      return downloadResponse;
+    }
+
+    usageRecords.push(...downloadResponse.response);
+  }
+
+  return {
+    status: "OK",
+    response: usageRecords.sort((left, right) =>
+      left.day.localeCompare(right.day),
+    ),
+  };
+};
+
+const fetchSeatAssignments = async (
+  filter: IFilter,
+  token: string,
+  version: string,
+): Promise<ServerActionResponse<SeatAssignment[]>> => {
+  const entityName = getEntityName(filter);
+  const seats: SeatAssignment[] = [];
+  let nextUrl = buildSeatsUrl(filter);
+
+  while (!stringIsNullOrEmpty(nextUrl)) {
+    const response = await fetch(nextUrl, {
+      cache: "no-store",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": version,
+      },
+    });
+
+    if (!response.ok) {
+      return formatResponseError(entityName, response);
+    }
+
+    const data = await response.json();
+
+    if (Array.isArray(data.seats)) {
+      seats.push(...(data.seats as SeatAssignment[]));
+    }
+
+    nextUrl = getNextUrlFromLinkHeader(response.headers.get("Link")) || "";
+  }
+
+  return {
+    status: "OK",
+    response: seats,
+  };
+};
+
+const buildUserTeamLookup = (seats: SeatAssignment[]) => {
+  const lookup = new Map<string, Set<string>>();
+
+  seats.forEach((seat) => {
+    const login = seat.assignee?.login?.toLowerCase();
+    const teamName = seat.assigning_team?.name;
+
+    if (!login || !teamName) {
+      return;
+    }
+
+    const teams = lookup.get(login) || new Set<string>();
+    teams.add(teamName);
+    lookup.set(login, teams);
+  });
+
+  return lookup;
+};
+
+const filterUsageRecordsByDate = (
+  usageRecords: UsageMetricsUserDayRecord[],
+  filter: IFilter,
+) => {
+  const startDay = filter.startDate
+    ? format(filter.startDate, "yyyy-MM-dd")
+    : undefined;
+  const endDay = filter.endDate
+    ? format(filter.endDate, "yyyy-MM-dd")
+    : undefined;
+
+  return usageRecords.filter((record) => {
+    if (startDay && record.day < startDay) {
+      return false;
+    }
+
+    if (endDay && record.day > endDay) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+const filterUsageRecordsByTeam = (
+  usageRecords: UsageMetricsUserDayRecord[],
+  selectedTeams: string[],
+  teamLookup: Map<string, Set<string>>,
+) => {
+  if (selectedTeams.length === 0) {
+    return usageRecords;
+  }
+
+  const selectedTeamSet = new Set(selectedTeams);
+
+  return usageRecords.filter((record) => {
+    const userTeams = teamLookup.get(record.user_login.toLowerCase());
+
+    if (!userTeams) {
+      return false;
+    }
+
+    for (const teamName of userTeams) {
+      if (selectedTeamSet.has(teamName)) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+};
+
+const mergeBreakdowns = (breakdowns: Breakdown[]) => {
+  const breakdownMap = new Map<string, Breakdown>();
+
+  breakdowns.forEach((breakdown) => {
+    const key = `${breakdown.language}::${breakdown.editor}::${breakdown.model}`;
+    const existing = breakdownMap.get(key);
+
+    if (existing) {
+      existing.suggestions_count += breakdown.suggestions_count;
+      existing.acceptances_count += breakdown.acceptances_count;
+      existing.lines_suggested += breakdown.lines_suggested;
+      existing.lines_accepted += breakdown.lines_accepted;
+      existing.active_users += breakdown.active_users;
+      return;
+    }
+
+    breakdownMap.set(key, { ...breakdown });
+  });
+
+  return Array.from(breakdownMap.values());
+};
+
+const buildCodeCompletionBreakdowns = (
+  usageRecord: UsageMetricsUserDayRecord,
+): Breakdown[] => {
+  const languageTotals = (usageRecord.totals_by_language_feature || []).filter(
+    (total) =>
+      total.feature === CODE_COMPLETION_FEATURE && hasUsageActivity(total),
+  );
+
+  if (languageTotals.length === 0) {
+    return [];
+  }
+
+  const ideTotals = (usageRecord.totals_by_ide || [])
+    .filter(hasUsageActivity)
+    .map((total) => {
+      const weight =
+        asNumber(total.code_generation_activity_count) ||
+        asNumber(total.code_acceptance_activity_count) ||
+        totalSuggestedLines(total) ||
+        totalAcceptedLines(total) ||
+        1;
+
+      return {
+        editor: total.ide.toLowerCase(),
+        weight,
+      };
+    });
+
+  const totalWeight = ideTotals.reduce((sum, total) => sum + total.weight, 0);
+  const editorWeights =
+    ideTotals.length > 0
+      ? ideTotals.map((total) => ({
+          editor: total.editor,
+          factor:
+            totalWeight > 0 ? total.weight / totalWeight : 1 / ideTotals.length,
+        }))
+      : [{ editor: "unknown", factor: 1 }];
+
+  return languageTotals.flatMap((total) =>
+    editorWeights.map(({ editor, factor }) => ({
+      language: total.language.toLowerCase(),
+      editor,
+      model: "default",
+      suggestions_count: scaleMetric(
+        asNumber(total.code_generation_activity_count),
+        factor,
+      ),
+      acceptances_count: scaleMetric(
+        asNumber(total.code_acceptance_activity_count),
+        factor,
+      ),
+      lines_suggested: scaleMetric(totalSuggestedLines(total), factor),
+      lines_accepted: scaleMetric(totalAcceptedLines(total), factor),
+      active_users: scaleMetric(1, factor),
+    })),
+  );
+};
+
+const isEngagedUsageRecord = (usageRecord: UsageMetricsUserDayRecord) =>
+  asNumber(usageRecord.user_initiated_interaction_count) > 0 ||
+  asNumber(usageRecord.code_acceptance_activity_count) > 0 ||
+  isChatUsageRecord(usageRecord);
+
+const isChatUsageRecord = (usageRecord: UsageMetricsUserDayRecord) =>
+  Boolean(
+    usageRecord.used_chat ||
+    usageRecord.used_agent ||
+    usageRecord.used_copilot_cloud_agent ||
+    usageRecord.used_copilot_coding_agent ||
+    (usageRecord.totals_by_feature || []).some(
+      (featureTotal) =>
+        isChatFeature(featureTotal.feature) && hasUsageActivity(featureTotal),
+    ),
+  );
+
+const sumFeatureTotals = (
+  usageRecord: UsageMetricsUserDayRecord,
+  predicate: (feature: string) => boolean,
+) => {
+  return (usageRecord.totals_by_feature || [])
+    .filter((featureTotal) => predicate(featureTotal.feature))
+    .reduce(
+      (totals, featureTotal) => {
+        totals.userInteractions += asNumber(
+          featureTotal.user_initiated_interaction_count,
+        );
+        totals.codeGeneration += asNumber(
+          featureTotal.code_generation_activity_count,
+        );
+        totals.codeAcceptances += asNumber(
+          featureTotal.code_acceptance_activity_count,
+        );
+        totals.linesSuggested += totalSuggestedLines(featureTotal);
+        totals.linesAccepted += totalAcceptedLines(featureTotal);
+        return totals;
+      },
+      {
+        userInteractions: 0,
+        codeGeneration: 0,
+        codeAcceptances: 0,
+        linesSuggested: 0,
+        linesAccepted: 0,
+      },
+    );
+};
+
+const addUsageTimeFrameLabels = (
+  usageOutputs: CopilotUsageOutput[],
+): CopilotUsageOutput[] => {
+  return [...usageOutputs]
+    .sort((left, right) => left.day.localeCompare(right.day))
+    .map((usageOutput) => {
+      const date = new Date(usageOutput.day);
+      const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+      const weekIdentifier = format(weekStart, "MMM dd");
+      const monthIdentifier = format(date, "MMM yy");
+
+      return {
+        ...usageOutput,
+        time_frame_week: weekIdentifier,
+        time_frame_month: monthIdentifier,
+        time_frame_display: weekIdentifier,
+      };
+    });
+};
+
+const aggregateUsageRecordsByDay = (
+  usageRecords: UsageMetricsUserDayRecord[],
+): CopilotUsageOutput[] => {
+  const recordsByDay = usageRecords.reduce((grouped, usageRecord) => {
+    if (!grouped.has(usageRecord.day)) {
+      grouped.set(usageRecord.day, []);
+    }
+
+    grouped.get(usageRecord.day)!.push(usageRecord);
+    return grouped;
+  }, new Map<string, UsageMetricsUserDayRecord[]>());
+
+  const usageOutputs = Array.from(recordsByDay.entries()).map(
+    ([day, dayRecords]) => {
+      const activeUsers = new Set<string>();
+      const engagedUsers = new Set<string>();
+      const ideEngagedUsers = new Set<string>();
+      const chatUsers = new Set<string>();
+      const breakdowns: Breakdown[] = [];
+
+      let totalCodeSuggestions = 0;
+      let totalCodeAcceptances = 0;
+      let totalCodeLinesSuggested = 0;
+      let totalCodeLinesAccepted = 0;
+      let totalChats = 0;
+      let totalChatAcceptances = 0;
+
+      dayRecords.forEach((usageRecord) => {
+        const login = usageRecord.user_login.toLowerCase();
+        activeUsers.add(login);
+
+        if (isEngagedUsageRecord(usageRecord)) {
+          engagedUsers.add(login);
+        }
+
+        const codeCompletionTotals = sumFeatureTotals(
+          usageRecord,
+          (feature) => feature === CODE_COMPLETION_FEATURE,
+        );
+
+        if (
+          codeCompletionTotals.codeGeneration > 0 ||
+          codeCompletionTotals.codeAcceptances > 0 ||
+          codeCompletionTotals.linesSuggested > 0 ||
+          codeCompletionTotals.linesAccepted > 0
+        ) {
+          ideEngagedUsers.add(login);
+        }
+
+        if (isChatUsageRecord(usageRecord)) {
+          chatUsers.add(login);
+        }
+
+        totalCodeSuggestions += codeCompletionTotals.codeGeneration;
+        totalCodeAcceptances += codeCompletionTotals.codeAcceptances;
+        totalCodeLinesSuggested += codeCompletionTotals.linesSuggested;
+        totalCodeLinesAccepted += codeCompletionTotals.linesAccepted;
+
+        const chatTotals = sumFeatureTotals(usageRecord, isChatFeature);
+        totalChats += chatTotals.userInteractions;
+        totalChatAcceptances += chatTotals.codeAcceptances;
+
+        breakdowns.push(...buildCodeCompletionBreakdowns(usageRecord));
+      });
+
+      return {
+        total_active_users: activeUsers.size,
+        total_engaged_users: engagedUsers.size,
+        total_ide_engaged_users: ideEngagedUsers.size,
+        total_code_suggestions: totalCodeSuggestions,
+        total_code_acceptances: totalCodeAcceptances,
+        total_code_lines_suggested: totalCodeLinesSuggested,
+        total_code_lines_accepted: totalCodeLinesAccepted,
+        total_chat_engaged_users: chatUsers.size,
+        total_chats: totalChats,
+        total_chat_insertion_events: totalChatAcceptances,
+        total_chat_copy_events: 0,
+        day,
+        breakdown: mergeBreakdowns(breakdowns),
+        time_frame_week: "",
+        time_frame_month: "",
+        time_frame_display: "",
+      };
+    },
+  );
+
+  return addUsageTimeFrameLabels(usageOutputs);
+};
+
+const getCopilotMetricsFromUsageReport = async (
+  filter: IFilter,
+  token: string,
+  version: string,
+): Promise<ServerActionResponse<CopilotUsageOutput[]>> => {
+  const usageRecordsResponse = await fetchUsageUserDayRecords(
+    filter,
+    token,
+    version,
+  );
+
+  if (usageRecordsResponse.status !== "OK") {
+    return usageRecordsResponse;
+  }
+
+  let usageRecords = filterUsageRecordsByDate(
+    usageRecordsResponse.response,
+    filter,
+  );
+
+  if (filter.team && filter.team.length > 0) {
+    const seatAssignmentsResponse = await fetchSeatAssignments(
+      filter,
+      token,
+      version,
+    );
+
+    if (seatAssignmentsResponse.status !== "OK") {
+      return seatAssignmentsResponse;
+    }
+
+    usageRecords = filterUsageRecordsByTeam(
+      usageRecords,
+      filter.team,
+      buildUserTeamLookup(seatAssignmentsResponse.response),
+    );
+  }
+
+  return {
+    status: "OK",
+    response: aggregateUsageRecordsByDay(usageRecords),
+  };
+};
+
 export const getCopilotMetrics = async (
-  filter: IFilter
+  filter: IFilter,
 ): Promise<ServerActionResponse<CopilotUsageOutput[]>> => {
   const env = ensureGitHubEnvConfig();
   const isCosmosConfig = cosmosConfiguration();
@@ -40,84 +635,35 @@ export const getCopilotMetrics = async (
           filter.organization = organization;
         }
         break;
-    }    if (isCosmosConfig) {
+    }
+    if (isCosmosConfig) {
       return getCopilotMetricsFromDatabase(filter);
     }
-    
+
     // If teams are specified, use the teams-specific API function
     if (filter.team && filter.team.length > 0) {
       return getCopilotTeamsMetricsFromApi(filter);
     }
-    
+
     return getCopilotMetricsFromApi(filter);
   } catch (e) {
     return unknownResponseError(e);
   }
 };
 
-const fetchCopilotMetrics = async (
-  url: string,
-  token: string,
-  version: string,
-  entityName: string
-): Promise<ServerActionResponse<CopilotUsageOutput[]>> => {
-  const response = await fetch(url, {
-    cache: "no-store",
-    headers: {
-      Accept: `application/vnd.github+json`,
-      Authorization: `Bearer ${token}`,
-      "X-GitHub-Api-Version": version,
-    },
-  });
-
-  if (!response.ok) {
-    return formatResponseError(entityName, response);
-  }
-
-  const data = await response.json();
-  const dataWithTimeFrame = applyTimeFrameLabel(data);
-  return {
-    status: "OK",
-    response: dataWithTimeFrame,
-  };
-};
-
 export const getCopilotMetricsFromApi = async (
-  filter: IFilter
+  filter: IFilter,
 ): Promise<ServerActionResponse<CopilotUsageOutput[]>> => {
   const env = ensureGitHubEnvConfig();
 
   if (env.status !== "OK") {
     return env;
   }
-  
-  if (filter.team && filter.team.length > 0) {
-    return getCopilotTeamsMetricsFromApi(filter);
-  }
 
   const { token, version } = env.response;
 
   try {
-    const queryParams = new URLSearchParams();
-
-    if (filter.startDate) {
-      queryParams.append("since", format(filter.startDate, "yyyy-MM-dd"));
-    }
-    if (filter.endDate) {
-      queryParams.append("until", format(filter.endDate, "yyyy-MM-dd"));
-    }
-
-    const queryString = queryParams.toString()
-      ? `?${queryParams.toString()}`
-      : "";
-
-    if (filter.enterprise) {
-      const url = `https://api.github.com/enterprises/${filter.enterprise}/copilot/metrics${queryString}`;
-      return fetchCopilotMetrics(url, token, version, filter.enterprise);
-    } else {
-      const url = `https://api.github.com/orgs/${filter.organization}/copilot/metrics${queryString}`;
-      return fetchCopilotMetrics(url, token, version, filter.organization);
-    }
+    return getCopilotMetricsFromUsageReport(filter, token, version);
   } catch (e) {
     return unknownResponseError(e);
   }
@@ -138,69 +684,9 @@ export const getCopilotTeamsMetricsFromApi = async (
   }
 
   const { token, version } = env.response;
+
   try {
-    // If no teams specified, return empty array
-    if (!filter.team || filter.team.length === 0) {
-      return {
-        status: "OK",
-        response: [],
-      };
-    }
-
-    const queryParams = new URLSearchParams();
-
-    if (filter.startDate) {
-      queryParams.append("since", format(filter.startDate, "yyyy-MM-dd"));
-    }
-    if (filter.endDate) {
-      queryParams.append("until", format(filter.endDate, "yyyy-MM-dd"));
-    }
-
-    const queryString = queryParams.toString()
-      ? `?${queryParams.toString()}`
-      : "";
-
-    // Fetch metrics for each team and combine results
-    const teamMetricsPromises = filter.team.map(async (teamSlug) => {
-      let url: string;
-      let entityName: string;
-
-      if (filter.enterprise) {
-        // For enterprise-level team metrics
-        url = `https://api.github.com/enterprises/${filter.enterprise}/team/${teamSlug}/copilot/metrics${queryString}`;
-        entityName = `${filter.enterprise}/team/${teamSlug}`;
-      } else {
-        // For organization-level team metrics
-        url = `https://api.github.com/orgs/${filter.organization}/team/${teamSlug}/copilot/metrics${queryString}`;
-        entityName = `${filter.organization}/team/${teamSlug}`;
-      }
-
-      return fetchCopilotMetrics(url, token, version, entityName);
-    });
-
-    const teamMetricsResults = await Promise.all(teamMetricsPromises);
-
-    // Check if any requests failed
-    const failedResults = teamMetricsResults.filter(result => result.status !== "OK");
-    if (failedResults.length > 0) {
-      // Return the first error encountered
-      return failedResults[0];
-    }
-
-    // Combine all successful results
-    const allMetrics: CopilotUsageOutput[] = [];
-    teamMetricsResults.forEach(result => {
-      if (result.status === "OK") {
-        allMetrics.push(...result.response);
-      }    });
-
-    // Sort by day to maintain consistency
-    allMetrics.sort((a, b) => new Date(a.day).getTime() - new Date(b.day).getTime());
-
-    return {
-      status: "OK",
-      response: allMetrics,
-    };
+    return getCopilotMetricsFromUsageReport(filter, token, version);
   } catch (e) {
     return unknownResponseError(e);
   }

--- a/src/dashboard/services/copilot-metrics-service.ts
+++ b/src/dashboard/services/copilot-metrics-service.ts
@@ -1,3 +1,29 @@
+/**
+ * Copilot metrics service
+ * -----------------------
+ *
+ * Sources Copilot usage data and shapes it into `CopilotUsageOutput[]` for
+ * the dashboard UI. Three back-ends, in priority order:
+ *
+ *   1. CosmosDB           — when `AZURE_COSMOSDB_ENDPOINT` is set,
+ *                           pre-ingested daily snapshots are queried.
+ *   2. GitHub API (live)  — otherwise we hit GitHub directly:
+ *                              a) /copilot/metrics/reports/users-28-day/latest
+ *                                 returns one or more pre-signed download
+ *                                 links to JSON or NDJSON files of per-user,
+ *                                 per-day usage records.
+ *                              b) /copilot/billing/seats provides the
+ *                                 seat <-> team mapping so we can attribute
+ *                                 each usage record to one or more teams.
+ *                           The two are joined and rolled up by day.
+ *   3. Sample data        — fallback used in `_getCopilotMetrics` for
+ *                           local development without GitHub credentials.
+ *
+ * The aggregation contract preserved for the UI is `CopilotUsageOutput[]`,
+ * one entry per (day, optional team) combination, with breakdowns by
+ * language and IDE. The chat-vs-completion split is derived from feature
+ * names (anything starting with `chat_` or containing `agent` is chat).
+ */
 import { formatResponseError, unknownResponseError } from "@/features/common/response-error";
 import {
   Breakdown,

--- a/src/dashboard/services/env-service.ts
+++ b/src/dashboard/services/env-service.ts
@@ -18,9 +18,23 @@ export const ensureGitHubEnvConfig = (): ServerActionResponse<GitHubConfig> => {
   const enterprise = process.env.GITHUB_ENTERPRISE;
   const token = process.env.GITHUB_TOKEN;
   const version = process.env.GITHUB_API_VERSION;
-  let scope = process.env.GITHUB_API_SCOPE;
+  const scope = process.env.GITHUB_API_SCOPE || "organization";
 
-  if (stringIsNullOrEmpty(organization)) {
+  if (validateScope(scope)) {
+    return {
+      status: "ERROR",
+      errors: [
+        {
+          message:
+            "Invalid GitHub API scope: " +
+            scope +
+            ". Value must be 'enterprise' or 'organization'",
+        },
+      ],
+    };
+  }
+
+  if (scope === "organization" && stringIsNullOrEmpty(organization)) {
     return {
       status: "ERROR",
       errors: [
@@ -31,7 +45,7 @@ export const ensureGitHubEnvConfig = (): ServerActionResponse<GitHubConfig> => {
     };
   }
 
-  if (stringIsNullOrEmpty(enterprise)) {
+  if (scope === "enterprise" && stringIsNullOrEmpty(enterprise)) {
     return {
       status: "ERROR",
       errors: [
@@ -66,29 +80,11 @@ export const ensureGitHubEnvConfig = (): ServerActionResponse<GitHubConfig> => {
     };
   }
 
-  if (validateScope(scope)) {
-    return {
-      status: "ERROR",
-      errors: [
-        {
-          message:
-            "Invalid GitHub API scope: " +
-            scope +
-            ". Value must be 'enterprise' or 'organization'",
-        },
-      ],
-    };
-  }
-
-  if (stringIsNullOrEmpty(scope)) {
-    scope = "organization";
-  }
-
   return {
     status: "OK",
     response: {
-      organization,
-      enterprise,
+      organization: organization || "",
+      enterprise: enterprise || "",
       token,
       version,
       scope,

--- a/src/dashboard/tsconfig.json
+++ b/src/dashboard/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
> [!WARNING]
> **The Copilot Metrics API used by `main` was sunset on 2026-04-02.**
> Without this PR, every metrics call from `services/copilot-metrics-service.ts` returns **404** and the dashboard renders no data on a fresh deployment today.
> Tracking issue: [microsoft/copilot-metrics-dashboard#87](https://github.com/microsoft/copilot-metrics-dashboard/issues/87) · GitHub changelog: ["Closing down notice of legacy Copilot metrics APIs" (2026-01-29)](https://github.blog/changelog/2026-01-29-closing-down-notice-of-legacy-copilot-metrics-apis/).

Closes #87

## What this changes
This PR rewires `services/copilot-metrics-service.ts` to source metrics from the **user-day usage report** instead of the per-day metrics endpoint, joins the result with seat assignments, and relaxes environment-variable validation so org-only deployments don't have to set `GITHUB_ENTERPRISE`.

The output type (`CopilotUsageOutput[]`) consumed by the dashboard UI is **unchanged**, so no UI work is required.

See [#87](https://github.com/microsoft/copilot-metrics-dashboard/issues/87) for the rationale and [docs/metrics-ingestion.md](https://github.com/a-magdy/copilot-metrics-dashboard/blob/main/docs/metrics-ingestion.md) added in this PR for an end-to-end walkthrough.

## Data flow summary

```
GET /copilot/metrics/reports/users-28-day/latest
  -> { download_links: [...] }
  -> for each link, GET <link>
       -> JSON or NDJSON of UsageMetricsUserDayRecord rows

GET /copilot/billing/seats?per_page=100  (paginated)
  -> SeatAssignment[]
  -> derive userLogin -> teams[] map

Join, filter by date / team, aggregate by (day, language, IDE, feature),
output CopilotUsageOutput[].
```

## Why move off the per-day endpoint?
The per-day endpoint (`/orgs/{org}/copilot/metrics`) returns counters already aggregated by day/IDE/language. It does **not** expose per-user data, so we couldn't:

- Distinguish licensed-but-inactive users from engaged ones.
- Group by team without one extra API call per team.
- Cleanly separate chat usage from completion usage.

The user-day usage report exposes the underlying per-user, per-day rows. All three become local computations; the cost is the extra download + aggregation that this PR adds.

## Why touch `env-service.ts`?
Today the validator requires **all** of `GITHUB_ORGANIZATION`, `GITHUB_ENTERPRISE`, `GITHUB_TOKEN`, `GITHUB_API_VERSION` regardless of `GITHUB_API_SCOPE`. That contradicts the README and forces org-scope users to set a dummy `GITHUB_ENTERPRISE` value. This PR makes the requirement scope-aware:

- `scope=organization` → require `GITHUB_ORGANIZATION`, ignore `GITHUB_ENTERPRISE`.
- `scope=enterprise`   → require `GITHUB_ENTERPRISE`, ignore `GITHUB_ORGANIZATION`.
- `scope` defaults to `organization` if unset.

## Why `tsconfig.json`?
The new aggregation iterates over `Set` values. TypeScript's default `target: "es5"` rejects native `for ... of` over `Set` (`--downlevelIteration` would also work but is global noise). Setting `target: "es2015"` is the simplest fix and matches what every supported Node version runs natively.

## Files
| File | Change |
| --- | --- |
| `src/dashboard/services/copilot-metrics-service.ts` | Switch live ingestion to the user-day usage report; join with seat data; aggregate by day/team/feature. File header explains the three back-ends. |
| `src/dashboard/services/env-service.ts` | Scope-aware env validation, default scope to `organization`. |
| `src/dashboard/tsconfig.json` | `target: "es2015"`. |
| `docs/metrics-ingestion.md` | End-to-end documentation of the new flow, field reference, and migration rationale. |

## Verification
- `npm run build` — lint + type-check + production build all pass.
- `npm run dev` — `/` and `/seats` render against a live org.

## Notes for reviewers
- Each `download_link` may return either a JSON array or NDJSON; both are handled in `parseUsageUserReport`.
- All HTTP calls use `cache: "no-store"` because the dashboard always wants fresh data.
- A user is "engaged" on a day when any activity counter or LOC sum is > 0 (`hasUsageActivity`).
- Chat-vs-completion classification is feature-name based: `chat_*` or anything containing `agent` is chat; everything else is treated as completion.


## Context — why now?
The user-day usage report API didn't exist when the dashboard was last updated.

| Date | Event |
| --- | --- |
| Oct 2024 | Per-day Copilot Metrics API (the one `main` currently uses) goes GA. |
| Feb 2025 | Beta `/usage` endpoints deprecated. |
| **2025-07-29** | **Last upstream commit on `main`** (`01ef37d`). |
| **2025-10-28** | Copilot usage metrics dashboard + **user-day usage report** API enters public preview ([changelog](https://github.blog/changelog/2025-10-28-copilot-usage-metrics-dashboard-and-api-in-public-preview/)). This is the `/copilot/metrics/reports/users-28-day/latest` endpoint this PR adopts. |

So the new endpoint is roughly three months newer than `main`. The motivation for switching to it (per-user granularity, native team attribution, clean chat-vs-completion split) is described in #87.


